### PR TITLE
Fix podman build instructions for initrd

### DIFF
--- a/rhcos-layer/initrd/Containerfile
+++ b/rhcos-layer/initrd/Containerfile
@@ -13,7 +13,8 @@ WORKDIR /
 COPY ${CA_CERTS_FILE} /
 COPY ${REGISTRY_AUTH_FILE} /
 
-RUN if [ ${CA_CERTS_FILE} ]; then \
+RUN rm -f /envfile && \
+    if [ ${CA_CERTS_FILE} ]; then \
         echo "CA_CERTS_FILE=/${CA_CERTS_FILE}" >> /envfile; \
     else \
         echo "CA_CERTS_FILE=" >> /envfile; \

--- a/rhcos-layer/initrd/README.md
+++ b/rhcos-layer/initrd/README.md
@@ -3,9 +3,20 @@
 You can use the Containerfile in this folder to create a custom
 RHCOS image layer with Kata initrd containing CA certs and Registry auth file.
 
+- Copy the required certs to a single file (eg. tls.crt)
+
+- Copy all the required registry auths to a single json file (eg. auth.json) . The file must be in
+  [auth-json format](https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md)
+
+- Build the image
+
 ```sh
 sudo podman build --build-arg RHCOS_COCO_IMAGE=<rhcos-coco-image> \
-             --build-arg CA_CERTS_FILE=<ca-certs-file> \
-             --build-arg REGISTRY_AUTH_FILE=<registry-auth-file> \
+             --build-arg CA_CERTS_FILE=tls.crt \
+             --build-arg REGISTRY_AUTH_FILE=auth.json \
+             --env CA_CERTS_FILE=tls.crt \
+             --env REGISTRY_AUTH_FILE=auth.json \
              -t <new-rhcos-coco-image> -f Containerfile .
 ```
+
+- Push it to registry


### PR DESCRIPTION
podman build is not overriding the ENV variables that's already set
in the base image. For example the base image has CA_CERTS_FILE set to
empty string. The new build using the same base image is not overriding
the CA_CERTS_FILE via build-args.
You need to explicitly override it via `--env` option during build.
For example `--env CA_CERTS_FILE=tls.crt`

This issue is not there with docker.