### PR TITLE
containerfiles: tdx-qgs: add missing libsgx-dcap-default-qpl

### DIFF
--- a/containerfiles/tdx-qgs/Containerfile
+++ b/containerfiles/tdx-qgs/Containerfile
@@ -6,7 +6,7 @@ WORKDIR /opt/intel
 RUN curl https://download.01.org/intel-sgx/sgx-dcap/${DCAP_VERSION}/linux/distro/rhel9.4-server/sgx_rpm_local_repo.tgz | tar zx && \
     dnf install --assumeyes --setopt=install_weak_deps=False boost-system boost-thread && \
     dnf config-manager --add-repo file:///opt/intel/sgx_rpm_local_repo && \
-    dnf install --nogpgcheck --assumeyes --setopt=install_weak_deps=False tdx-qgs && \
+    dnf install --nogpgcheck --assumeyes --setopt=install_weak_deps=False tdx-qgs libsgx-dcap-default-qpl && \
     dnf config-manager --disable opt_intel_sgx_rpm_local_repo && \
     rm -r /opt/intel/sgx_rpm_local_repo
 


### PR DESCRIPTION
QGS container errors during TD quote generation:
[get_qpl_handle ../td_ql_logic.cpp:174] Cannot open Quote Provider Library libdcap_quoteprov.so.1 [read_persistent_data ../td_ql_logic.cpp:886] Couldn't find the platform library. libdcap_quoteprov.so.1: cannot open shared object file: No such file or directory

The quote is sent OK but with "Cert Type = 3". However, the verifier expects "Cert Type = 5" so Trustee gets:

"Verifier evaluate failed: TDX Verifier: tee_verify_quote failed: 0xe01c". 0xe01c maps to SGX_QL_QUOTE_CERTIFICATION_DATA_UNSUPPORTED.