### PR TITLE
containerfiles: dcap-registration-flow: add missing enclave packages

### DIFF
--- a/containerfiles/dcap-registration-flow/Containerfile
+++ b/containerfiles/dcap-registration-flow/Containerfile
@@ -5,7 +5,12 @@ ARG DCAP_VERSION=1.23
 WORKDIR /opt/intel
 RUN curl https://download.01.org/intel-sgx/sgx-dcap/${DCAP_VERSION}/linux/distro/rhel9.4-server/sgx_rpm_local_repo.tgz | tar zx && \
     dnf config-manager --add-repo file:///opt/intel/sgx_rpm_local_repo && \
-    dnf install --nogpgcheck --assumeyes --setopt=install_weak_deps=False sgx-pck-id-retrieval-tool libsgx-urts libsgx-ra-uefi && \
+    dnf install --nogpgcheck --assumeyes --setopt=install_weak_deps=False \
+    sgx-pck-id-retrieval-tool \
+    libsgx-urts \
+    libsgx-ae-pce \
+    libsgx-ae-id-enclave \
+    libsgx-ra-uefi && \
     dnf config-manager --disable opt_intel_sgx_rpm_local_repo && \
     rm -r /opt/intel/sgx_rpm_local_repo
 


### PR DESCRIPTION
The contents of sgx-pck-id-retrieval-tool-1.23.100.0-1.el9.x86_64 RPM suggests that it has the necessary enclaves installed:
```
/opt/intel/sgx-pck-id-retrieval-tool
/opt/intel/sgx-pck-id-retrieval-tool/License.txt
/opt/intel/sgx-pck-id-retrieval-tool/PCKIDRetrievalTool /opt/intel/sgx-pck-id-retrieval-tool/README.txt
/opt/intel/sgx-pck-id-retrieval-tool/libsgx_id_enclave.signed.so.1 /opt/intel/sgx-pck-id-retrieval-tool/libsgx_pce.signed.so.1 /opt/intel/sgx-pck-id-retrieval-tool/network_setting.conf /usr/lib/.build-id
/usr/lib/.build-id/a4
/usr/lib/.build-id/a4/29e221420f6830e9fe461c90819c2f50e8e980
```
but that does not seem to be enough for the tool to function. Running the tool errors with:
```
Error, call sgx_create_enclave: fail [load_enclave], SGXError:200f.
```
It does work if the two enclaves are installed from their own RPM packages: `libsgx-ae-id-enclave-1.23.100.0-1.el9.x86_64` and libsgx-ae-pce-2.26.100.0-1.el9.x86_64`.