### PR TITLE
initrd-builder: update the podvm-payload image reference to use the 1.12 builds

### DIFF
--- a/containerfiles/initrd-builder/argfile.conf
+++ b/containerfiles/initrd-builder/argfile.conf
@@ -1,7 +1,7 @@
 # podvm_payload image from where we get kata binaries artifacts, e.g. pause-bundle, kata-agent and guest components
 # https://github.com/openshift/cloud-api-adaptor/tree/osc-release
 # Must be RHEL 10 based
-PODVM_PAYLOAD_IMAGE=quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:911df63d29774d519271597888e30f093a42a6c4a56ac62e939199ecdbec47d2
+PODVM_PAYLOAD_IMAGE=quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-12@sha256:0a3a3c29e6a3bd3fdfed9402479711a3fd179dbee9d995a058dc812948b98790
 # Base image used to build the NVIDIA drivers
 # Must be RHEL 10 based
 NVIDIA_DRIVERS_BASE_IMAGE=registry.access.redhat.com/ubi10:10.1-1772441712


### PR DESCRIPTION
Fixes: [KATA-5167](https://redhat.atlassian.net/browse/KATA-5167)