### PR TITLE
release: update CPE label version to 1.130

### DIFF
--- a/containerfiles/storage-helper/Containerfile
+++ b/containerfiles/storage-helper/Containerfile
@@ -35,7 +35,7 @@ RUN microdnf clean all
 
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-storage-helper" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.13::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
 version="1.13" \
 com.redhat.component="osc-storage-helper" \
 summary="Openshift Sandboxed Containers Storage Helper" \


### PR DESCRIPTION
ProdSec product-definitions registers the OSC 1.13 stream with CPE version 1.130. Update the Containerfile to match.

Signed-off-by: Daniel Kreling <dkreling@redhat.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>