### PR TITLE
konflux: add a tag to our images that mentions the PR it built from

### DIFF
--- a/.tekton/initrd-builder-pull-request.yaml
+++ b/.tekton/initrd-builder-pull-request.yaml
@@ -532,6 +532,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/osc-storage-helper-pull-request.yaml
+++ b/.tekton/osc-storage-helper-pull-request.yaml
@@ -547,6 +547,10 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+        - pr-{{pull_request_number}}
+        - pullreq-{{pull_request_number}}-{{revision}}
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
Identifying images on quay is hard. This commit makes sure we tag our image with the PR number it was built from. This should make it easier to identify what image we can use for testing a build before we merge the PR.

We create 2 tags, for different purposes:
- pr-[PR number]: this is overriden on each build, and tags the latest build
- pullreq-[PR number]-[head commit SHA]: provides an easy to find tag, while keeping an history of builds.