### PR TITLE
konflux: update the tekton files for building 1.13 from new branch

### DIFF
--- a/.tekton/initrd-builder-pull-request.yaml
+++ b/.tekton/initrd-builder-pull-request.yaml
@@ -9,14 +9,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main" && ( "containerfiles/initrd-builder/***".pathChanged() || ".tekton/initrd-builder-pull-request.yaml".pathChanged()
+      == "osc-release-v1.13" && ( "containerfiles/initrd-builder/***".pathChanged() || ".tekton/initrd-builder-pull-request.yaml".pathChanged()
       )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: build-initrds
-    appstudio.openshift.io/component: initrd-builder
+    appstudio.openshift.io/application: build-initrds-v1-13
+    appstudio.openshift.io/component: initrd-builder-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: initrd-builder-on-pull-request
+  name: initrd-builder-v1-13-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/initrd-builder:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/initrd-builder-v1-13:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile
@@ -598,7 +598,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-initrd-builder
+    serviceAccountName: build-pipeline-initrd-builder-v1-13
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/initrd-builder-push.yaml
+++ b/.tekton/initrd-builder-push.yaml
@@ -8,14 +8,14 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main" && ( "containerfiles/initrd-builder/***".pathChanged() || ".tekton/initrd-builder-push.yaml".pathChanged()
+      == "osc-release-v1.13" && ( "containerfiles/initrd-builder/***".pathChanged() || ".tekton/initrd-builder-push.yaml".pathChanged()
       )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: build-initrds
-    appstudio.openshift.io/component: initrd-builder
+    appstudio.openshift.io/application: build-initrds-v1-13
+    appstudio.openshift.io/component: initrd-builder-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: initrd-builder-on-push
+  name: initrd-builder-v1-13-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/initrd-builder:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/initrd-builder-v1-13:{{revision}}
   - name: dockerfile
     value: Containerfile
   - name: path-context
@@ -591,7 +591,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-initrd-builder
+    serviceAccountName: build-pipeline-initrd-builder-v1-13
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-storage-helper-pull-request.yaml
+++ b/.tekton/osc-storage-helper-pull-request.yaml
@@ -8,13 +8,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ( "containerfiles/storage-helper/***".pathChanged() || ".tekton/osc-storage-helper-pull-request.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "osc-release-v1.13" && ( "containerfiles/storage-helper/***".pathChanged() || ".tekton/osc-storage-helper-pull-request.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-storage-helper
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-13
+    appstudio.openshift.io/component: osc-storage-helper-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: osc-storage-helper-on-pull-request
+  name: osc-storage-helper-v1-13-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper-v1-13:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -613,7 +613,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-storage-helper
+    serviceAccountName: build-pipeline-osc-storage-helper-v1-13
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-storage-helper-push.yaml
+++ b/.tekton/osc-storage-helper-push.yaml
@@ -7,13 +7,13 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ( "containerfiles/storage-helper/***".pathChanged() || ".tekton/osc-storage-helper-push.yaml".pathChanged() )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "osc-release-v1.13" && ( "containerfiles/storage-helper/***".pathChanged() || ".tekton/osc-storage-helper-push.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-storage-helper
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-13
+    appstudio.openshift.io/component: osc-storage-helper-v1-13
     pipelines.appstudio.openshift.io/type: build
-  name: osc-storage-helper-on-push
+  name: osc-storage-helper-v1-13-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-storage-helper-v1-13:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -606,7 +606,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-storage-helper
+    serviceAccountName: build-pipeline-osc-storage-helper-v1-13
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.

Fixes: [KATA-5601](https://redhat.atlassian.net/browse/KATA-5601)