### PR TITLE
initrd-builder: add NFSv4 and RPCSEC_GSS modules to kata-cc initrd

### DIFF
--- a/containerfiles/initrd-builder/osbuilder/dracut/dracut.conf.d/15-dracut.conf
+++ b/containerfiles/initrd-builder/osbuilder/dracut/dracut.conf.d/15-dracut.conf
@@ -29,7 +29,7 @@ drivers+=" vfio_pci vfio_iommu_type1 "
 drivers+=" ptp_kvm "
 
 # overlay, storage etc.
-drivers+=" overlay nfs dm-crypt dm-verity dm-mod libiscsi "
+drivers+=" overlay nfs nfsv4 rpcsec_gss_krb5 dm-crypt dm-verity dm-mod libiscsi "
 
 # Extra dracut modules
 dracutmodules+=" "


### PR DESCRIPTION
Add nfsv4 and rpcsec_gss_krb5 to dracut drivers. Without these, NFSv4 mounts fail with Protocol not supported inside kata-cc pods. Fixes: OCPBUGS-98989