### PR TITLE
[1.13] initrd-builders: update the argfile to reference the image built from this branch

### DIFF
--- a/containerfiles/initrd-builder/argfile.conf
+++ b/containerfiles/initrd-builder/argfile.conf
@@ -1,7 +1,7 @@
 # podvm_payload image from where we get kata binaries artifacts, e.g. pause-bundle, kata-agent and guest components
 # https://github.com/openshift/cloud-api-adaptor/tree/osc-release
 # Must be RHEL 10 based
-PODVM_PAYLOAD_IMAGE=quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload@sha256:1b4762b4b8aa28a8ce4de28f64a72aafc0f0c75a5ccec805177ec840593ccc64
+PODVM_PAYLOAD_IMAGE=quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-13@sha256:517928ce09ba21b0971acf31cc2a92d9a1e7b2e557ad52d7b512262df127ff72
 # Base image used to build the NVIDIA drivers
 # Must be RHEL 10 based
 NVIDIA_DRIVERS_BASE_IMAGE=registry.access.redhat.com/ubi10:10.2-1781510001


### PR DESCRIPTION
Our pipelines running from the release branch produce an image that have a suffix "-v[release version]". References to these images from the quay repo must have the same suffix, to be able to pick the right image.

Fixes: [KATA-5601](https://redhat.atlassian.net/browse/KATA-5601)